### PR TITLE
DefaultAuthenticator authentication should not depend on the default JVM Locale

### DIFF
--- a/src/main/java/com/ingenico/connect/gateway/sdk/java/defaultimpl/DefaultAuthenticator.java
+++ b/src/main/java/com/ingenico/connect/gateway/sdk/java/defaultimpl/DefaultAuthenticator.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -146,7 +147,7 @@ public class DefaultAuthenticator implements Authenticator {
 	}
 
 	private String toCanonicalizeHeaderName(String originalName) {
-		return originalName == null ? null : originalName.toLowerCase();
+		return originalName == null ? null : originalName.toLowerCase(Locale.ENGLISH);
 	}
 
 	String toCanonicalizeHeaderValue(String originalValue) {


### PR DESCRIPTION
The current implementation will not generate the same signature based on
the jvm default locale

Example :
if your jvm is set to the tr locale (running with -Duser.language=tr or
changing the os language)
then the connect server will reject the api call
(MISSING_OR_INVALID_AUTHORIZATION)

this commit changes the header name canonicalization by using
Locale.ENGLISH instead of relying on the default one.

Fix #6 