### PR TITLE
DefaultAuthenticator#toCanonicalizeHeaderValue creates and compiles a Regex pattern for each header

### DIFF
--- a/src/main/java/com/ingenico/connect/gateway/sdk/java/defaultimpl/DefaultAuthenticator.java
+++ b/src/main/java/com/ingenico/connect/gateway/sdk/java/defaultimpl/DefaultAuthenticator.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -25,6 +26,7 @@ public class DefaultAuthenticator implements Authenticator {
 	private static final Charset CHARSET = Charset.forName("UTF-8");
 
 	private static final String HMAC_ALGORITHM = "HmacSHA256";
+	private static final Pattern CANONICALIZE_HEADER_REGEXP = Pattern.compile("\r?\n[\\s&&[^\r\n]]*");
 
 	private static final Comparator<RequestHeader> REQUEST_HEADER_COMPARATOR = new Comparator<RequestHeader>() {
 		@Override
@@ -155,7 +157,7 @@ public class DefaultAuthenticator implements Authenticator {
 			return "";
 		}
 
-		return originalValue.replaceAll("\r?\n[\\s&&[^\r\n]]*", " ").trim();
+		return CANONICALIZE_HEADER_REGEXP.matcher(originalValue).replaceAll(" ").trim();
 	}
 
 	/*


### PR DESCRIPTION
Re-use the pattern which is thread safe.
Reduce cpu usage.

Fix #10 