### PR TITLE
DefaultAuthenticator#toDataToSign is allocating to much memory

### DIFF
--- a/src/main/java/com/ingenico/connect/gateway/sdk/java/defaultimpl/DefaultAuthenticator.java
+++ b/src/main/java/com/ingenico/connect/gateway/sdk/java/defaultimpl/DefaultAuthenticator.java
@@ -92,7 +92,6 @@ public class DefaultAuthenticator implements Authenticator {
 
 		String contentType = null;
 		String date = null;
-		StringBuilder canonicalizedHeaders = new StringBuilder();
 		String canonicalizedResource = toCanonicalizedResource(resourceUri);
 
 		List<RequestHeader> xgcsHttpHeaders = new ArrayList<RequestHeader>();
@@ -117,20 +116,19 @@ public class DefaultAuthenticator implements Authenticator {
 
 		Collections.sort(xgcsHttpHeaders, REQUEST_HEADER_COMPARATOR);
 
+		StringBuilder sb = new StringBuilder(100);
+		sb.append(httpMethod.toUpperCase()).append('\n');
+		if (contentType != null) {
+			sb.append(contentType).append('\n');
+		} else {
+			sb.append('\n');
+		}
+		sb.append(date).append('\n');
 		for (RequestHeader xgcsHttpHeader: xgcsHttpHeaders) {
-			canonicalizedHeaders.append(xgcsHttpHeader.getName()).append(":").append(xgcsHttpHeader.getValue()).append("\n");
+			sb.append(xgcsHttpHeader.getName()).append(':').append(xgcsHttpHeader.getValue()).append('\n');
 		}
 
-		StringBuilder sb = new StringBuilder();
-		sb.append(httpMethod.toUpperCase()).append("\n");
-		if (contentType != null) {
-			sb.append(contentType).append("\n");
-		} else {
-			sb.append("\n");
-		}
-		sb.append(date).append("\n");
-		sb.append(canonicalizedHeaders.toString());
-		sb.append(canonicalizedResource).append("\n");
+		sb.append(canonicalizedResource).append('\n');
 
 		return sb.toString();
 	}
@@ -140,11 +138,14 @@ public class DefaultAuthenticator implements Authenticator {
 	 * decoded query parameters.
 	 */
 	private String toCanonicalizedResource(URI resourceUri) {
-		StringBuilder sb = new StringBuilder();
-		sb.append(resourceUri.getRawPath());
-		if (resourceUri.getQuery() != null) {
-			sb.append("?").append(resourceUri.getQuery());
+		String rawPath = resourceUri.getRawPath();
+		if (resourceUri.getQuery() == null) {
+			return rawPath;
 		}
+
+		StringBuilder sb = new StringBuilder();
+		sb.append(rawPath);
+		sb.append('?').append(resourceUri.getQuery());
 		return sb.toString();
 	}
 


### PR DESCRIPTION
Mainly due the string buffer re-allocations.
Use a single buffer instead of 2 and give it a sane default size (the
X-GCS-ServerMetaInfo header value is huge).
Avoid useless buffer allocation if the uri has no query part.